### PR TITLE
Adding column hidden save/restore.

### DIFF
--- a/NSTableView+RSAutosaving.h
+++ b/NSTableView+RSAutosaving.h
@@ -12,6 +12,7 @@
 
 extern NSString * const RSAutosavingColumnWidthKey;
 extern NSString * const RSAutosavingColumnIndexKey;
+extern NSString* const RSAutosavingColumnHiddenKey;
 
 @interface NSTableView (RSAutosaving)
 - (NSDictionary *)dictionaryForAutosavingLayout;

--- a/NSTableView+RSAutosaving.m
+++ b/NSTableView+RSAutosaving.m
@@ -17,6 +17,8 @@
 
 NSString * const RSAutosavingColumnWidthKey = @"AutosavedColumnWidth";
 NSString * const RSAutosavingColumnIndexKey = @"AutosavedColumnIndex";
+NSString* const RSAutosavingColumnHiddenKey = @"AutosavedColumnHidden";
+
 
 @interface NSDictionary (RSTableViewAutosaving)
 - (NSComparisonResult)compareByAutosavedIndex:(NSDictionary *)otherDict;
@@ -46,6 +48,7 @@ NSString * const RSAutosavingColumnIndexKey = @"AutosavedColumnIndex";
 		NSInteger thisColIndex = [self columnWithIdentifier:thisColID];
 		NSNumber *thisIndex = @(thisColIndex);
 		thisColDict[RSAutosavingColumnIndexKey] = thisIndex;
+		thisColDict[RSAutosavingColumnHiddenKey] = @(thisCol.isHidden);
 		
 		// Add it all to the big dict
 		autoDict[thisColID] = thisColDict;
@@ -93,6 +96,9 @@ NSString * const RSAutosavingColumnIndexKey = @"AutosavedColumnIndex";
 			thisCol.width = (CGFloat)columnWidthNum.doubleValue;
 #endif
 			thisCol.resizingMask = saveMask;
+			
+			if(thisColDict[RSAutosavingColumnHiddenKey])
+				thisCol.hidden = [thisColDict[RSAutosavingColumnHiddenKey] boolValue];
 		}
 	}
 }


### PR DESCRIPTION
Since columns can be hidden, this was needed to keep them hidden when restoring a doc.